### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,8 +211,20 @@
             "properties": {
                 "ahk++.executePath": {
                     "type": "string",
-                    "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
-                    "description": "The execute path of AHK."
+                    "default": "C:/Program Files/Autohotkey/AutoHotkey.exe",
+                    "description": "AutoHotkey executable path.",
+                    "enum": [
+                        "C:/Program Files/Autohotkey/AutoHotkey.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyA32.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyU32.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyU64.exe"
+                    ],
+                    "enumDescriptions": [
+                        "AutoHotkey executable (insatllation default).",
+                        "AutoHotkeyA32 executable.",
+                        "AutoHotkeyU32 executable.",
+                        "AutoHotkeyU64 executable."
+                    ]
                 },
                 "ahk++.compilePath": {
                     "type": "string",


### PR DESCRIPTION
Add all AutoHotkey executables to the extension's settings `Ahk++: Execute Path`.

I often find the need to toggle between AutoHotkey.exe (AutoHotkeyU64.exe by default) and AutoHotkeyA32.exe. This would be so much more convenient if this was available from the command palette or especially the editor context menu.