### PR TITLE
format: fix indentation for hotkeys {:: and }::

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.format.semicolons": "insert"
+}

--- a/format_test_cases/{} match testing.ahk
+++ b/format_test_cases/{} match testing.ahk
@@ -1,0 +1,35 @@
+{::
+    if () 
+    {
+        ok:="}"
+        ok:="{"
+        ok:="}:"
+        ok:="{:"
+        ok:="{}"
+        sleep, 100
+        ok:={a:[{b:1,a:3,c:{1,2,3}},{b:1,a:3,c:{1,2,3}},{b:1,a:3,c:{1,2,3}}]}
+        ok:={b:1,a:3,c:{1,2,3}}
+        ok:={b:1,a:3}
+        sleep, 100
+        if (true) {
+            sleep, 100
+        } else {
+            send, {{}{}}{left}
+        }
+    } 
+    else 
+    {
+        send, {{}
+    }
+}
+
+return
+f1::
+    sleep, 100
+return
+f2::
+    sleep, 100
+return
+}::
+return
+f3::Exitapp

--- a/package.json
+++ b/package.json
@@ -211,8 +211,20 @@
             "properties": {
                 "ahk++.executePath": {
                     "type": "string",
-                    "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
-                    "description": "The execute path of AHK."
+                    "default": "C:/Program Files/AutoHotkey/AutoHotkey.exe",
+                    "description": "AutoHotkey executable path.",
+                    "enum": [
+                        "C:/Program Files/Autohotkey/AutoHotkey.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyA32.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyU32.exe",
+                        "C:/Program Files/Autohotkey/AutoHotkeyU64.exe"
+                    ],
+                    "enumDescriptions": [
+                        "AutoHotkey executable (insatllation default).",
+                        "AutoHotkeyA32 executable.",
+                        "AutoHotkeyU32 executable.",
+                        "AutoHotkeyU64 executable."
+                    ]
                 },
                 "ahk++.compilePath": {
                     "type": "string",

--- a/src/common/codeUtil.ts
+++ b/src/common/codeUtil.ts
@@ -3,7 +3,19 @@ export class CodeUtil {
      * trim unfoucs code.
      * @param origin any string
      */
-    public static purity(origin: string): string {
+    public static purity_greedy(origin: string): string {
+        if (!origin) return '';
+        // TODO: untest
+        return origin
+            .replace(/;.+/, '')
+            .replace(/".*?"/g, '')
+            .replace(/\{.*\}/g, '')
+            .replace(/ +/g, ' ')
+            .replace(/\bgui\b.*/gi, '')
+            .replace(/\b(msgbox)\b.+?%/gi, '$1');
+    }
+
+    public static purity(origin: string, greedy: boolean = false): string {
         if (!origin) return '';
         // TODO: untest
         return origin

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export function activate(context: vscode.ExtensionContext) {
             new FormatProvider(),
         ),
         vscode.languages.registerReferenceProvider(language, new RefProvider()),
-        TemplateProvider.createEditorListenr(),
+        TemplateProvider.createEditorListener(),
         vscode.debug.registerDebugAdapterDescriptorFactory(
             'ahk',
             new InlineDebugAdapterFactory(),

--- a/src/provider/formattingProvider.ts
+++ b/src/provider/formattingProvider.ts
@@ -55,7 +55,8 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 }
                 continue;
             }
-            const purityText = CodeUtil.purity(originText.toLowerCase());
+            const purityText = CodeUtil.purity_greedy(originText.toLowerCase());
+            // console.log(purityText)
             let notDeep = true;
 
             if (
@@ -69,9 +70,9 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 }
                 notDeep = false;
             }
-
+            // \bword\b:whole words only, /i:case insensitive
             if (purityText.match(/\b(return)\b/i) && tagDeep === deep) {
-                tagDeep == 0;
+                tagDeep == 0; //this does nothing
                 deep--;
                 notDeep = false;
             }
@@ -87,16 +88,11 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 }
             }
 
-            if (purityText.match(/}/) != null) {
-                let temp = purityText.match(/}/).length;
-                const t2 = purityText.match(/{[^{}]*}/);
-                if (t2) {
-                    temp = temp - t2.length;
+            if (purityText.includes("}")) {
+                if (!purityText.includes("}:")) {
+                    deep--;
                 }
-                deep -= temp;
-                if (temp > 0) {
-                    notDeep = false;
-                }
+                notDeep = false;
             }
 
             if (oneCommandCode && purityText.match(/{/) != null) {
@@ -143,16 +139,11 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 notDeep = false;
             }
 
-            if (purityText.match(/{/) != null) {
-                let temp = purityText.match(/{/).length;
-                const t2 = purityText.match(/{[^{}]*}/);
-                if (t2) {
-                    temp = temp - t2.length;
+            if (purityText.includes("{")) {
+                if (!purityText.includes("{:")) {
+                    deep++;
                 }
-                deep += temp;
-                if (temp > 0) {
-                    notDeep = false;
-                }
+                notDeep = false;
             }
 
             if (purityText.match(/:\s*$/)) {

--- a/src/provider/templateProvider.ts
+++ b/src/provider/templateProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 export class TemplateProvider {
-    public static createEditorListenr(): vscode.Disposable {
+    public static createEditorListener(): vscode.Disposable {
         return vscode.window.onDidChangeActiveTextEditor((e) => {
             if (
                 e &&


### PR DESCRIPTION
having {:: or }:: as hotkey breaks the indentation...
you can reproduce issue with \format_test_cases\\{} match testing.ahk