### PR TITLE
Correct "category" for Run Selection command

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
             {
                 "command": "ahk++.runSelection",
                 "title": "Run Selection",
-                "category": "AHK"
+                "category": "AHK++"
             }
         ],
         "menus": {


### PR DESCRIPTION
CHANGE: `"category": "AHK"` to `"category": "AHK++"`

Notifying @mark-wiemer
