### PR TITLE
fix #56 issue with wrong Return statement indent

### DIFF
--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -109,7 +109,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 purifiedLine.match(/\b(return|ExitApp)\b/i) &&
                 tagDepth === depth
             ) {
-                tagDepth === 0;
+                tagDepth = 0;
                 depth--;
                 atTopLevel = false;
             }


### PR DESCRIPTION
Closes #56.

Changes proposed in this pull request:

-   fix typo comparison '===' to assignment '='

Notifying @mark-wiemer
