### PR TITLE
Feature: Trim end of line

### DIFF
--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -64,10 +64,11 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             /** The line comment. Empty string if no line comment exists */
             const comment = /;.+/.exec(originalLine)?.[0] ?? '';
             const formattedLine = originalLine
-                .replace(/^\s*/, '')
                 .replace(/;.+/, '')
                 .replace(/ {2,}/g, ' ')
-                .concat(comment);
+                .trim()
+                .concat(' ' + comment)
+                .trim();
 
             atTopLevel = true;
 

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -21,6 +21,7 @@ const formatTests: FormatTest[] = [
     { filenameRoot: '25-multiline-string' },
     { filenameRoot: '58-parentheses-indentation' },
     { filenameRoot: '72-paren-hotkey' },
+    { filenameRoot: '189-space-at-end-of-line' },
     { filenameRoot: 'ahk-explorer' },
     { filenameRoot: 'demo' },
     {

--- a/src/test/suite/format/samples/189-space-at-end-of-line.in.ahk
+++ b/src/test/suite/format/samples/189-space-at-end-of-line.in.ahk
@@ -1,0 +1,3 @@
+; [Issue #189](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/189)
+foo()    
+foo(a,    b)    ;    comment     

--- a/src/test/suite/format/samples/189-space-at-end-of-line.out.ahk
+++ b/src/test/suite/format/samples/189-space-at-end-of-line.out.ahk
@@ -1,0 +1,3 @@
+; [Issue #189](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/189)
+foo()
+foo(a, b) ;    comment


### PR DESCRIPTION
Closes #189.

Changes proposed in this pull request:

-   trim original line after comment remove
-   concat comment with extra leading space
-   trim result string

---

Notifying @mark-wiemer
