### PR TITLE
Add option to extension's settings: "Trim extra spaces between words"

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
+                },
+                "ahk++.trimExtraSpaces": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Formatter: Trim extra spaces between words"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
                 "ahk++.formatter.trimExtraSpaces": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Trim extra spaces between words"
+                    "description": "Trim extra spaces between words."
                 },
                 "ahk++.helpPath": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
                     "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
                     "description": "Path to the AHK runner."
                 },
+                "ahk++.formatter.trimExtraSpaces": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Trim extra spaces between words"
+                },
                 "ahk++.helpPath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",
@@ -111,11 +116,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
-                },
-                "ahk++.trimExtraSpaces": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Formatter: Trim extra spaces between words"
                 }
             }
         },

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,5 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
-    trimExtraSpaces = 'trimExtraSpaces',
+    trimExtraSpaces = 'formatter.trimExtraSpaces',
 }

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,4 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
+    trimExtraSpaces = 'trimExtraSpaces',
 }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -68,12 +68,10 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             const purifiedLine = CodeUtil.purify(originalLine.toLowerCase());
             /** The line comment. Empty string if no line comment exists */
             const comment = /;.+/.exec(originalLine)?.[0] ?? '';
-            let formattedLine = originalLine
-                .replace(/;.+/, '') // Remove single line comment
-                .trimStart();
+            let formattedLine = originalLine.replace(/;.+/, ''); // Remove single line comment
             formattedLine = trimExtraSpaces(formattedLine, trimSpaces) // Remove extra spaces between words
                 .concat(comment) // Add removed single line comment back
-                .trimEnd();
+                .trim();
 
             atTopLevel = true;
 

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import { CodeUtil } from '../common/codeUtil';
+import { ConfigKey, Global } from '../common/global';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
     trimExtraSpaces,
 } from './formattingProvider.utils';
-import { Global, ConfigKey } from '../common/global';
 
 function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
     const lastLineId = document.lineCount - 1;

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -68,13 +68,12 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             const purifiedLine = CodeUtil.purify(originalLine.toLowerCase());
             /** The line comment. Empty string if no line comment exists */
             const comment = /;.+/.exec(originalLine)?.[0] ?? '';
-            let formattedLine = originalLine;
-            formattedLine = formattedLine.replace(/;.+/, ''); // Remove single line comment
-            formattedLine = formattedLine.replace(/^\s*/, ''); // Remove leading spaces/tabs
-            formattedLine = trimExtraSpaces(formattedLine, trimSpaces); // Remove extra spaces between words
-            formattedLine = formattedLine
+            let formattedLine = originalLine
+                .replace(/;.+/, '') // Remove single line comment
+                .trimStart();
+            formattedLine = trimExtraSpaces(formattedLine, trimSpaces) // Remove extra spaces between words
                 .concat(comment) // Add removed single line comment back
-                .trim(); // Trim spaces after comment text
+                .trimEnd();
 
             atTopLevel = true;
 

--- a/src/providers/formattingProvider.utils.ts
+++ b/src/providers/formattingProvider.utils.ts
@@ -17,3 +17,13 @@ export function hasMoreOpenParens(line: string): boolean {
     const closeCount = line.match(/\)/g)?.length ?? 0;
     return openCount > closeCount;
 }
+
+/** @return string with trimmed extra spaces between words*/
+export function trimExtraSpaces(
+    line: string,
+    trimExtraSpaces: boolean,
+): string {
+    return trimExtraSpaces
+        ? line.replace(/ {2,}/g, ' ') // Remove extra spaces between words
+        : line;
+}

--- a/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
+++ b/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
+    trimExtraSpaces,
 } from '../../../../providers/formattingProvider.utils';
 
 suite('FormattingProvider utils', () => {
@@ -72,6 +73,44 @@ suite('FormattingProvider utils', () => {
             test("'" + data.in + "'" + ' => ' + data.rs.toString(), () => {
                 assert.strictEqual(hasMoreOpenParens(data.in), data.rs);
             });
+        });
+    });
+
+    suite('trimExtraSpaces', () => {
+        // List of test data
+        let dataList = [
+            // {
+            //     in: , // input test string
+            //     rs: , // expected result
+            //     ts: , // trim extra spaces
+            // },
+            {
+                in: 'InputFile    :=    "movie.mkv"',
+                rs: 'InputFile := "movie.mkv"',
+                ts: true,
+            },
+            {
+                in: 'InputFile    :=    "movie.mkv"',
+                rs: 'InputFile    :=    "movie.mkv"',
+                ts: false,
+            },
+        ];
+        dataList.forEach((data) => {
+            test(
+                'Trim(' +
+                    data.ts.toString() +
+                    "): '" +
+                    data.in +
+                    "' => '" +
+                    data.rs +
+                    "'",
+                () => {
+                    assert.strictEqual(
+                        trimExtraSpaces(data.in, data.ts),
+                        data.rs,
+                    );
+                },
+            );
         });
     });
 });

--- a/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
+++ b/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
@@ -94,6 +94,11 @@ suite('FormattingProvider utils', () => {
                 rs: 'InputFile    :=    "movie.mkv"',
                 ts: false,
             },
+            {
+                in: 'MsgBox,  4,   , testing   testing',
+                rs: 'MsgBox, 4, , testing testing',
+                ts: true,
+            },
         ];
         dataList.forEach((data) => {
             test(


### PR DESCRIPTION
Closes #187.

Changes proposed in this pull request:

-   make trimming extra spaces between words optional

---

Notifying @mark-wiemer
