### PR TITLE
Add option to extension's settings: "Preserve indentation on empty line" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
                 "ahk++.formatter.preserveIndent": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Preserve indentation on empty line"
+                    "description": "Preserve indentation on empty line."
                 },
                 "ahk++.helpPath": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
                     "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
                     "description": "Path to the AHK runner."
                 },
+                "ahk++.formatter.preserveIndent": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Preserve indentation on empty line"
+                },
                 "ahk++.helpPath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",
@@ -111,11 +116,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
-                },
-                "ahk++.preserveIndent": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Formatter: Preserve indentation on empty line"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
+                },
+                "ahk++.preserveIndent": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Formatter: Preserve indentation on empty line"
                 }
             }
         },

--- a/src/common/codeUtil.ts
+++ b/src/common/codeUtil.ts
@@ -13,7 +13,8 @@ export class CodeUtil {
             .replace(/{.*}/g, '') // remove matching braces
             .replace(/ +/g, ' ')
             .replace(/\bgui\b.*/gi, '')
-            .replace(/\b(msgbox)\b.+?%/gi, '$1');
+            .replace(/\b(msgbox)\b.+?%/gi, '$1')
+            .trim();
     }
 
     /**

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,5 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
-    preserveIndent = 'preserveIndent',
+    preserveIndent = 'formatter.preserveIndent',
 }

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,4 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
+    preserveIndent = 'preserveIndent',
 }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -149,6 +149,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                         blockCommentLine,
                         depth,
                         options,
+                        preserveIndentOnEmptyString,
                     );
                 }
                 if (originalLine.match(/^\s*\*\//)) {
@@ -245,6 +246,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 formattedLine,
                 depth,
                 options,
+                preserveIndentOnEmptyString,
             );
 
             // Next line

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { CodeUtil } from '../common/codeUtil';
+import { ConfigKey, Global } from '../common/global';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
@@ -57,6 +58,10 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
         let oneCommandCode = false;
         let blockComment = false;
         let atTopLevel = true;
+
+        const preserveIndentOnEmptyString = Global.getConfig<boolean>(
+            ConfigKey.preserveIndent,
+        );
 
         for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
             const originalLine = document.lineAt(lineIndex).text;
@@ -166,9 +171,11 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             const indentationChars = options.insertSpaces
                 ? ' '.repeat(depth * options.tabSize)
                 : '\t'.repeat(depth);
-            formattedDocument += !formattedLine?.trim()
-                ? formattedLine
-                : indentationChars + formattedLine;
+            let indentedLine = indentationChars + formattedLine;
+            if (!preserveIndentOnEmptyString) {
+                indentedLine = indentedLine.trim();
+            }
+            formattedDocument += indentedLine;
 
             // If not last line, add newline
             if (lineIndex !== document.lineCount - 1) {

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -73,6 +73,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 .replace(/;.+/, '')
                 .replace(/ {2,}/g, ' ')
                 .concat(comment);
+            const emptyLine = purifiedLine === '';
 
             atTopLevel = true;
 
@@ -172,7 +173,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                 ? ' '.repeat(depth * options.tabSize)
                 : '\t'.repeat(depth);
             let indentedLine = indentationChars + formattedLine;
-            if (!preserveIndentOnEmptyString) {
+            if (emptyLine && !preserveIndentOnEmptyString) {
                 indentedLine = indentedLine.trim();
             }
             formattedDocument += indentedLine;

--- a/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
+++ b/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
@@ -69,37 +69,57 @@ suite('FormattingProvider utils', () => {
             //     dp: , // depth of indentation
             //     fl: , // formatted line
             //     op: , // formatting options
+            //     pi: , // preserve indent
             //     rs: , // expected result
             // },
             {
                 dp: 0,
                 fl: 'SoundBeep',
                 op: { insertSpaces: true, tabSize: 4 },
+                pi: false,
                 rs: 'SoundBeep',
             },
             {
                 dp: 1,
                 fl: 'SoundBeep',
                 op: { insertSpaces: true, tabSize: 4 },
+                pi: false,
                 rs: '    SoundBeep',
             },
             {
                 dp: 2,
                 fl: 'SoundBeep',
                 op: { insertSpaces: true, tabSize: 4 },
+                pi: false,
                 rs: '        SoundBeep',
             },
             {
                 dp: 1,
                 fl: 'SoundBeep',
                 op: { insertSpaces: false, tabSize: 4 },
+                pi: false,
                 rs: '\tSoundBeep',
             },
             {
                 dp: 2,
                 fl: 'SoundBeep',
                 op: { insertSpaces: false, tabSize: 4 },
+                pi: false,
                 rs: '\t\tSoundBeep',
+            },
+            {
+                dp: 1,
+                fl: '',
+                op: { insertSpaces: true, tabSize: 4 },
+                pi: true,
+                rs: '    ',
+            },
+            {
+                dp: 2,
+                fl: '',
+                op: { insertSpaces: false, tabSize: 4 },
+                pi: true,
+                rs: '\t\t',
             },
         ];
         dataList.forEach((data) => {
@@ -108,6 +128,8 @@ suite('FormattingProvider utils', () => {
                     data.dp +
                     ' spaces:' +
                     data.op.insertSpaces.toString() +
+                    ' preserveIndent:' +
+                    data.pi.toString() +
                     " '" +
                     data.fl +
                     "' => '" +
@@ -115,7 +137,14 @@ suite('FormattingProvider utils', () => {
                     "'",
                 () => {
                     assert.strictEqual(
-                        buildIndentedLine(0, 1, data.fl, data.dp, data.op),
+                        buildIndentedLine(
+                            0,
+                            1,
+                            data.fl,
+                            data.dp,
+                            data.op,
+                            data.pi,
+                        ),
                         data.rs,
                     );
                 },
@@ -227,9 +256,39 @@ suite('FormattingProvider utils', () => {
                 rs: 'text\n\n\n\ntext\n\n\n\n',
             },
             {
+                in: 'text\n    \n    \n    \n    \ntext\n    \n    \n    \n    \n',
+                ln: 0,
+                rs: 'text\ntext\n',
+            },
+            {
+                in: 'text\n    \n    \n    \n    \ntext\n    \n    \n    \n    \n',
+                ln: 1,
+                rs: 'text\n    \ntext\n    \n',
+            },
+            {
+                in: 'text\n    \n    \n    \n    \ntext\n    \n    \n    \n    \n',
+                ln: 2,
+                rs: 'text\n    \n    \ntext\n    \n    \n',
+            },
+            {
+                in: 'text\n    \n    \n    \n    \ntext\n    \n    \n    \n    \n',
+                ln: 3,
+                rs: 'text\n    \n    \n    \ntext\n    \n    \n    \n',
+            },
+            {
                 in: '\n\n\ntext',
                 ln: 1,
                 rs: 'text',
+            },
+            {
+                in: '    \n',
+                ln: 1,
+                rs: '',
+            },
+            {
+                in: '\t\n',
+                ln: 1,
+                rs: '',
             },
             {
                 in: 'text\ntext',


### PR DESCRIPTION
Changes proposed in this pull request:

-   preserve indentation on empty line

```autohotkey
foo() {
    bar()
[4 spaces]
    return
}
```

---

Notifying @mark-wiemer
