### PR TITLE
Add option to extension's settings: "Allowed number of empty lines"

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
                 "ahk++.formatter.allowedNumberOfEmptyLines": {
                     "type": "integer",
                     "default": 1,
-                    "minimum": 1,
-                    "description": "Allowed number of empty lines."
+                    "minimum": -1,
+                    "description": "Allowed number of empty lines.\n-1: ignore empty lines.\n0: no empty lines."
                 },
                 "ahk++.helpPath": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
+                },
+                "ahk++.formatter.allowedNumberOfEmptyLines": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Allowed number of empty lines."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -103,8 +103,9 @@
                     "description": "Path to the AHK runner."
                 },
                 "ahk++.formatter.allowedNumberOfEmptyLines": {
-                    "type": "number",
+                    "type": "integer",
                     "default": 1,
+                    "minimum": 1,
                     "description": "Allowed number of empty lines."
                 },
                 "ahk++.helpPath": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
                     "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
                     "description": "Path to the AHK runner."
                 },
+                "ahk++.formatter.allowedNumberOfEmptyLines": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "Allowed number of empty lines."
+                },
                 "ahk++.helpPath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",
@@ -111,11 +116,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
-                },
-                "ahk++.formatter.allowedNumberOfEmptyLines": {
-                    "type": "number",
-                    "default": 1,
-                    "description": "Allowed number of empty lines."
                 }
             }
         },

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,5 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
-    allowedNumberOfEmptyLines = 'allowedNumberOfEmptyLines',
+    allowedNumberOfEmptyLines = 'formatter.allowedNumberOfEmptyLines',
 }

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -31,4 +31,5 @@ export enum ConfigKey {
     helpPath = 'helpPath',
     enableIntellisense = 'enableIntellisense',
     executePath = 'executePath',
+    allowedNumberOfEmptyLines = 'allowedNumberOfEmptyLines',
 }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { CodeUtil } from '../common/codeUtil';
+import { ConfigKey, Global } from '../common/global';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
@@ -235,10 +236,23 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             }
         }
 
+        const allowedNumberOfEmptyLines = Global.getConfig<number>(
+            ConfigKey.allowedNumberOfEmptyLines,
+        );
+        const newLineCharacterNumber =
+            allowedNumberOfEmptyLines > 1 ? allowedNumberOfEmptyLines + 1 : 2; // + 1 new line character from previous string with text
+        const newLineCharacter = new RegExp(
+            `\\n{${newLineCharacterNumber},}`,
+            'g',
+        );
+
         return [
             new vscode.TextEdit(
                 fullDocumentRange(document),
-                formattedDocument.replace(/\n{2,}/g, '\n\n'),
+                formattedDocument.replace(
+                    newLineCharacter,
+                    '\n'.repeat(newLineCharacterNumber),
+                ),
             ),
         ];
     }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -249,10 +249,14 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
         return [
             new vscode.TextEdit(
                 fullDocumentRange(document),
-                formattedDocument.replace(
-                    newLineCharacter,
-                    '\n'.repeat(newLineCharacterNumber),
-                ),
+                formattedDocument
+                    // remove extra empty lines
+                    .replace(
+                        newLineCharacter,
+                        '\n'.repeat(newLineCharacterNumber),
+                    )
+                    // remove empty lines in start of file
+                    .replace(/^\n*/, ''),
             ),
         ];
     }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -4,6 +4,7 @@ import { ConfigKey, Global } from '../common/global';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
+    removeEmptyLines,
 } from './formattingProvider.utils';
 
 function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
@@ -236,28 +237,13 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             }
         }
 
-        const allowedNumberOfEmptyLines = Global.getConfig<number>(
-            ConfigKey.allowedNumberOfEmptyLines,
-        );
-        const newLineCharacterNumber =
-            allowedNumberOfEmptyLines > 1 ? allowedNumberOfEmptyLines + 1 : 2; // + 1 new line character from previous string with text
-        const newLineCharacter = new RegExp(
-            `\\n{${newLineCharacterNumber},}`,
-            'g',
+        formattedDocument = removeEmptyLines(
+            formattedDocument,
+            Global.getConfig<number>(ConfigKey.allowedNumberOfEmptyLines),
         );
 
         return [
-            new vscode.TextEdit(
-                fullDocumentRange(document),
-                formattedDocument
-                    // remove extra empty lines
-                    .replace(
-                        newLineCharacter,
-                        '\n'.repeat(newLineCharacterNumber),
-                    )
-                    // remove empty lines at start of file
-                    .replace(/^\n*/, ''),
-            ),
+            new vscode.TextEdit(fullDocumentRange(document), formattedDocument),
         ];
     }
 }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -255,7 +255,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
                         newLineCharacter,
                         '\n'.repeat(newLineCharacterNumber),
                     )
-                    // remove empty lines in start of file
+                    // remove empty lines at start of file
                     .replace(/^\n*/, ''),
             ),
         ];

--- a/src/providers/formattingProvider.utils.ts
+++ b/src/providers/formattingProvider.utils.ts
@@ -24,6 +24,9 @@ export function removeEmptyLines(
     document: string,
     allowedNumberOfEmptyLines: number,
 ): string {
+    if (allowedNumberOfEmptyLines === -1) {
+        return document;
+    }
     const newLineCharacterNumber = allowedNumberOfEmptyLines + 1; // + 1 new line character from previous string with text
     const newLineCharacter = new RegExp(`\\n{${newLineCharacterNumber},}`, 'g');
     return (

--- a/src/providers/formattingProvider.utils.ts
+++ b/src/providers/formattingProvider.utils.ts
@@ -18,6 +18,8 @@ export function hasMoreOpenParens(line: string): boolean {
     return openCount > closeCount;
 }
 
+/** Remove empty lines at start of document and empty lines,
+ *  that exceed allowed number of empty lines. */
 export function removeEmptyLines(
     document: string,
     allowedNumberOfEmptyLines: number,

--- a/src/providers/formattingProvider.utils.ts
+++ b/src/providers/formattingProvider.utils.ts
@@ -17,3 +17,18 @@ export function hasMoreOpenParens(line: string): boolean {
     const closeCount = line.match(/\)/g)?.length ?? 0;
     return openCount > closeCount;
 }
+
+export function removeEmptyLines(
+    document: string,
+    allowedNumberOfEmptyLines: number,
+): string {
+    const newLineCharacterNumber = allowedNumberOfEmptyLines + 1; // + 1 new line character from previous string with text
+    const newLineCharacter = new RegExp(`\\n{${newLineCharacterNumber},}`, 'g');
+    return (
+        document
+            // remove extra empty lines
+            .replace(newLineCharacter, '\n'.repeat(newLineCharacterNumber))
+            // remove empty lines at start of file
+            .replace(/^\n*/, '')
+    );
+}

--- a/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
+++ b/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
@@ -85,14 +85,34 @@ suite('FormattingProvider utils', () => {
             //     rs: , // expected result
             // },
             {
-                in: '\ntext\n\n\n\ntext\n\n\n\n',
+                in: 'text\n\n\n\n\ntext\n\n\n\n\n',
+                ln: -1,
+                rs: 'text\n\n\n\n\ntext\n\n\n\n\n',
+            },
+            {
+                in: 'text\n\n\n\n\ntext\n\n\n\n\n',
+                ln: 0,
+                rs: 'text\ntext\n',
+            },
+            {
+                in: 'text\n\n\n\n\ntext\n\n\n\n\n',
                 ln: 1,
                 rs: 'text\n\ntext\n\n',
             },
             {
-                in: '\ntext\n\n\n\ntext\n\n\n\n',
+                in: 'text\n\n\n\n\ntext\n\n\n\n\n',
                 ln: 2,
                 rs: 'text\n\n\ntext\n\n\n',
+            },
+            {
+                in: 'text\n\n\n\n\ntext\n\n\n\n\n',
+                ln: 3,
+                rs: 'text\n\n\n\ntext\n\n\n\n',
+            },
+            {
+                in: '\n\n\ntext',
+                ln: 1,
+                rs: 'text',
             },
             {
                 in: 'text\ntext',
@@ -107,7 +127,9 @@ suite('FormattingProvider utils', () => {
         ];
         dataList.forEach((data) => {
             test(
-                "'" +
+                'ln:' +
+                    data.ln +
+                    " '" +
                     data.in.replace(/\n/g, '\\n') +
                     "' => '" +
                     data.rs.replace(/\n/g, '\\n') +

--- a/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
+++ b/src/test/suite/providers/formatting/formattingProvider.utils.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
     hasMoreCloseParens,
     hasMoreOpenParens,
+    removeEmptyLines,
 } from '../../../../providers/formattingProvider.utils';
 
 suite('FormattingProvider utils', () => {
@@ -72,6 +73,52 @@ suite('FormattingProvider utils', () => {
             test("'" + data.in + "'" + ' => ' + data.rs.toString(), () => {
                 assert.strictEqual(hasMoreOpenParens(data.in), data.rs);
             });
+        });
+    });
+
+    suite('removeEmptyLines', () => {
+        // List of test data
+        let dataList = [
+            // {
+            //     in: , // input test string
+            //     ln: , // allowed empty lines
+            //     rs: , // expected result
+            // },
+            {
+                in: '\ntext\n\n\n\ntext\n\n\n\n',
+                ln: 1,
+                rs: 'text\n\ntext\n\n',
+            },
+            {
+                in: '\ntext\n\n\n\ntext\n\n\n\n',
+                ln: 2,
+                rs: 'text\n\n\ntext\n\n\n',
+            },
+            {
+                in: 'text\ntext',
+                ln: 1,
+                rs: 'text\ntext',
+            },
+            {
+                in: 'text\n',
+                ln: 1,
+                rs: 'text\n',
+            },
+        ];
+        dataList.forEach((data) => {
+            test(
+                "'" +
+                    data.in.replace(/\n/g, '\\n') +
+                    "' => '" +
+                    data.rs.replace(/\n/g, '\\n') +
+                    "'",
+                () => {
+                    assert.strictEqual(
+                        removeEmptyLines(data.in, data.ln),
+                        data.rs,
+                    );
+                },
+            );
         });
     });
 });


### PR DESCRIPTION
Closes #182.
Closes #197.
Closes #198.

Changes proposed in this pull request:

- add new option
- delete leading empty lines in begin of file

formatter.allowedNumberOfEmptyLines = 2

### Unformatted input snippet

```autohotkey
[empty line]
[empty line]
[empty line]
InputFile := "movie.mkv" 



InputFile = movie.mkv
```

### Before this PR

```autohotkey
[empty line]
[empty line]
InputFile := "movie.mkv" 

InputFile = movie.mkv
```

### After this PR

```autohotkey
InputFile := "movie.mkv" 


InputFile = movie.mkv
```

Notifying @mark-wiemer
