### PR TITLE
Refactor: assign settings in groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,11 +92,6 @@
                     "default": "C:/Program Files/AutoHotkey/Compiler/Ahk2Exe.exe",
                     "description": "Path to the AHK compiler."
                 },
-                "ahk++.language.enableIntellisense": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable IntelliSense (Preview). Changes take effect after reload."
-                },
                 "ahk++.file.executePath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
@@ -106,6 +101,11 @@
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",
                     "description": "Path to the AHK Help document."
+                },
+                "ahk++.language.enableIntellisense": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable IntelliSense (Preview). Changes take effect after reload."
                 },
                 "ahk++.ui.showDebugButton": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
                     "default": true,
                     "description": "Enable IntelliSense (Preview). Changes take effect after reload."
                 },
-                "ahk++.ui.showDebugButton": {
+                "ahk++.menu.showDebugButton": {
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
@@ -259,7 +259,7 @@
             "editor/title": [
                 {
                     "command": "ahk++.debug",
-                    "when": "editorLangId == ahk && config.ahk++.ui.showDebugButton",
+                    "when": "editorLangId == ahk && config.ahk++.menu.showDebugButton",
                     "group": "navigation@1"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -87,27 +87,27 @@
             "type": "object",
             "title": "AutoHotkey Plus Plus",
             "properties": {
-                "ahk++.compilePath": {
+                "ahk++.file.compilePath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/Compiler/Ahk2Exe.exe",
                     "description": "Path to the AHK compiler."
                 },
-                "ahk++.enableIntellisense": {
+                "ahk++.language.enableIntellisense": {
                     "type": "boolean",
                     "default": true,
                     "description": "Enable IntelliSense (Preview). Changes take effect after reload."
                 },
-                "ahk++.executePath": {
+                "ahk++.file.executePath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkeyU64.exe",
                     "description": "Path to the AHK runner."
                 },
-                "ahk++.helpPath": {
+                "ahk++.file.helpPath": {
                     "type": "string",
                     "default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",
                     "description": "Path to the AHK Help document."
                 },
-                "ahk++.showDebugButton": {
+                "ahk++.ui.showDebugButton": {
                     "type": "boolean",
                     "default": true,
                     "description": "Show the Debug button in the editor title menu"
@@ -259,7 +259,7 @@
             "editor/title": [
                 {
                     "command": "ahk++.debug",
-                    "when": "editorLangId == ahk && config.ahk++.showDebugButton",
+                    "when": "editorLangId == ahk && config.ahk++.ui.showDebugButton",
                     "group": "navigation@1"
                 }
             ]

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -28,7 +28,7 @@ export class Global {
 
 export enum ConfigKey {
     compilePath = 'file.compilePath',
-    helpPath = 'file.helpPath',
     enableIntellisense = 'language.enableIntellisense',
     executePath = 'file.executePath',
+    helpPath = 'file.helpPath',
 }

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -27,8 +27,8 @@ export class Global {
 }
 
 export enum ConfigKey {
-    compilePath = 'compilePath',
-    helpPath = 'helpPath',
-    enableIntellisense = 'enableIntellisense',
-    executePath = 'executePath',
+    compilePath = 'file.compilePath',
+    helpPath = 'file.helpPath',
+    enableIntellisense = 'language.enableIntellisense',
+    executePath = 'file.executePath',
 }


### PR DESCRIPTION
Changes proposed in this pull request:

-   assign settings in groups (for my new settings in other PRs, that are already in group 'formatter')
-   sort settings and `enum ConfigKey` in alphabet order

![Settings](https://user-images.githubusercontent.com/964801/180637890-4dd14543-ac76-46bb-b221-0073ef0c6e00.jpg)

Notifying @mark-wiemer
