### PR TITLE
Update snippet #TEMPLATE

### DIFF
--- a/snippets/ahk.json
+++ b/snippets/ahk.json
@@ -2,8 +2,10 @@
     "AhkTemplate": {
         "prefix": "#TEMPLATE",
         "body": [
+            "#NoEnv",
             "#SingleInstance, Force",
-            "SendMode Input",
+            "SendMode, Input",
+            "SetBatchLines, -1",
             "SetWorkingDir, %A_ScriptDir%",
             ""
         ]


### PR DESCRIPTION
From official documentation:

Specifying `#NoEnv` is recommended for all new scripts because:

1. It significantly improves performance whenever empty variables are used in an expression or command. It also improves DllCall's performance when unquoted parameter types are used (e.g. int vs. "int").
2. It prevents script bugs caused by environment variables whose names unexpectedly match variables used by the script.
3. AutoHotkey v2 will make this behavior the default.

Use `SetBatchLines, -1` to never sleep (i.e. have the script run at maximum speed). In AutoHotkey v2 is the default behaviour.

Notifying @mark-wiemer
