### PR TITLE
Add option to indent code after label

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
                     "minimum": -1,
                     "description": "Allowed number of empty lines.\n-1: ignore empty lines.\n0: no empty lines."
                 },
+                "ahk++.formatter.indentCodeAfterLabel": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indent code after label."
+                },
                 "ahk++.formatter.preserveIndent": {
                     "type": "boolean",
                     "default": false,

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -32,6 +32,7 @@ export enum ConfigKey {
     enableIntellisense = 'language.enableIntellisense',
     executePath = 'file.executePath',
     helpPath = 'file.helpPath',
+    indentCodeAfterLabel = 'formatter.indentCodeAfterLabel',
     preserveIndent = 'formatter.preserveIndent',
     trimExtraSpaces = 'formatter.trimExtraSpaces',
 }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -76,6 +76,7 @@ export const internalFormat = (
     let preBlockCommentAtTopLevel = true;
     let preBlockCommentOneCommandCode = false;
 
+    const indentCodeAfterLabel = options.indentCodeAfterLabel;
     const preserveIndentOnEmptyString = options.preserveIndent;
     const trimSpaces = options.trimExtraSpaces;
 
@@ -202,7 +203,7 @@ export const internalFormat = (
             atTopLevel = false;
         } else if (purifiedLine.match(label)) {
             // default or hotkey
-            if (options.indentCodeAfterLabel) {
+            if (indentCodeAfterLabel) {
                 if (tagDepth > 0 && tagDepth === depth) {
                     depth--;
                     atTopLevel = false;
@@ -311,7 +312,7 @@ export const internalFormat = (
 
         // default or label
         if (!moreOpenParens && purifiedLine.match(label)) {
-            if (options.indentCodeAfterLabel) {
+            if (indentCodeAfterLabel) {
                 depth++;
                 tagDepth = depth;
                 atTopLevel = false;

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -202,9 +202,11 @@ export const internalFormat = (
             atTopLevel = false;
         } else if (purifiedLine.match(label)) {
             // default or hotkey
-            if (tagDepth > 0 && tagDepth === depth) {
-                depth--;
-                atTopLevel = false;
+            if (options.indentCodeAfterLabel) {
+                if (tagDepth > 0 && tagDepth === depth) {
+                    depth--;
+                    atTopLevel = false;
+                }
             }
         }
 
@@ -309,9 +311,11 @@ export const internalFormat = (
 
         // default or label
         if (!moreOpenParens && purifiedLine.match(label)) {
-            depth++;
-            tagDepth = depth;
-            atTopLevel = false;
+            if (options.indentCodeAfterLabel) {
+                depth++;
+                tagDepth = depth;
+                atTopLevel = false;
+            }
         }
 
         if (atTopLevel) {
@@ -355,6 +359,10 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
             ConfigKey.allowedNumberOfEmptyLines,
         );
 
+        const indentCodeAfterLabel = Global.getConfig<boolean>(
+            ConfigKey.indentCodeAfterLabel,
+        );
+
         const preserveIndent = Global.getConfig<boolean>(
             ConfigKey.preserveIndent,
         );
@@ -366,6 +374,7 @@ export class FormatProvider implements vscode.DocumentFormattingEditProvider {
         const formattedString = internalFormat(stringToFormat, {
             ...options,
             allowedNumberOfEmptyLines,
+            indentCodeAfterLabel,
             preserveIndent,
             trimExtraSpaces,
         });

--- a/src/providers/formattingProvider.types.ts
+++ b/src/providers/formattingProvider.types.ts
@@ -4,6 +4,7 @@ export type FormatOptions = Pick<
     vscode.FormattingOptions,
     'tabSize' | 'insertSpaces'
 > & {
+    indentCodeAfterLabel: boolean;
     preserveIndent: boolean;
     trimExtraSpaces: boolean;
     allowedNumberOfEmptyLines: number;

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -21,6 +21,7 @@ const defaultOptions = {
     tabSize: 4,
     insertSpaces: true,
     allowedNumberOfEmptyLines: 1,
+    indentCodeAfterLabel: true,
     preserveIndent: false,
     trimExtraSpaces: true,
 };
@@ -51,6 +52,14 @@ const formatTests: FormatTest[] = [
     },
     { filenameRoot: 'ahk-explorer' },
     { filenameRoot: 'demo' },
+    {
+        filenameRoot: 'indent-code-after-label-false',
+        options: { indentCodeAfterLabel: false },
+    },
+    {
+        filenameRoot: 'indent-code-after-label-true',
+        options: { indentCodeAfterLabel: true },
+    },
     {
         filenameRoot: 'insert-spaces-false',
         options: { insertSpaces: false },

--- a/src/test/suite/format/samples/indent-code-after-label-false.in.ahk
+++ b/src/test/suite/format/samples/indent-code-after-label-false.in.ahk
@@ -1,0 +1,5 @@
+Label1:
+MsgBox
+Label2:
+SoundBeep
+return

--- a/src/test/suite/format/samples/indent-code-after-label-false.out.ahk
+++ b/src/test/suite/format/samples/indent-code-after-label-false.out.ahk
@@ -1,0 +1,5 @@
+Label1:
+MsgBox
+Label2:
+SoundBeep
+return

--- a/src/test/suite/format/samples/indent-code-after-label-true.in.ahk
+++ b/src/test/suite/format/samples/indent-code-after-label-true.in.ahk
@@ -1,0 +1,5 @@
+Label1:
+MsgBox
+Label2:
+SoundBeep
+return

--- a/src/test/suite/format/samples/indent-code-after-label-true.out.ahk
+++ b/src/test/suite/format/samples/indent-code-after-label-true.out.ahk
@@ -1,0 +1,5 @@
+Label1:
+    MsgBox
+Label2:
+    SoundBeep
+return


### PR DESCRIPTION
Changes proposed in this pull request:

- new setting to disable indentation after label:

```autohotkey
;On
label:
    MsgBox
return

;Off
label:
MsgBox
return
```

Notifying @mark-wiemer
