### PR TITLE
Document contributing tests FAQ

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -48,6 +48,16 @@ To verify your fix worked as expected, we recommend following [test-driven devel
 
 This way, we'll alway have a test to ensure we don't [re-introduce a bug](https://en.wikipedia.org/wiki/Software_regression)
 
+### Writing Code FAQ
+
+#### Tests aren't working properly
+
+Question: Sometimes, when running tests via VS Code's Debug viewlet, I see results for tests that don't match the TypeScript tests.
+
+Answer: Try running `npm run pretest` before running tests.
+
+Explanation: The tests are written in TypeScript, but must be transpiled to JavaScript before executing. When switching branches, the TS may change while the JS stays the same. This can result in running stale tests via VS Code. Running `npm run test` in the console will always run fresh tests.
+
 ### Validate the build
 
 Please validate the build before opening a PR. Automated checks will have to pass before the PR can be merged.


### PR DESCRIPTION
Inform contributors how to resolve a common issue when running tests. When switching branches, the TS tests would update but the JS tests that are executed wouldn't. Running `npm run pretest` solves this issue.

-   Closes #220 

---

Replace "ISSUE" and "CHANGE" above with your values.

Do not edit below:

Notifying @mark-wiemer
