### PR TITLE
Add "Formatter Known Issues" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The only directive currently supported is `FormatBlockComment` and it's used as 
 
 #### Formatter Known Issues
 
-There are commands, that can produce indent on single next line. For example:
+Some commands cause the next line to be indented. For example:
 
 ```autohotkey
 if (true)
@@ -162,7 +162,7 @@ Loop % n
 
 Such code will be well formatted.
 
-But do not nest such commands. The next code will be formatted incorrectly:
+However, the formatter doesn't work with nested commands:
 
 ```autohotkey
 if (true)
@@ -174,7 +174,7 @@ Loop % n
         SoundBeep
 ```
 
-Use their variants with braces:
+As a workaround, use braces:
 
 ```autohotkey
 if (true) {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ AHK++ is a fork of [AutoHotkey Plus by cweijan](https://github.com/AutoHotkey-Pl
     -   [Folding](#folding)
     -   [Code Format](#code-format)
         -   [Formatter Directives](#formatter-directives)
-        -   [Formatter Known Issues](#formatter-known-issues)
 -   [Credits](#credits)
 
 ## Why AutoHotkey Plus Plus?
@@ -130,6 +129,8 @@ Collapse me!
 
 ### Code Format
 
+> There are some [known issues with the formatter](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues?q=is%3Aopen+is%3Aissue+label%3Aformatter), and we're always working to improve.
+
 Supports standard VS Code formatting with a few options.
 
 ![Code Format](image/codeFormat.jpg)
@@ -147,10 +148,6 @@ The only directive currently supported is `FormatBlockComment` and it's used as 
 */
 ;@AHK++FormatBlockCommentOff
 ```
-
-#### Formatter Known Issues
-
-Look at [GitHub](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues?q=is%3Aopen+is%3Aissue+label%3Aformatter)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -150,43 +150,7 @@ The only directive currently supported is `FormatBlockComment` and it's used as 
 
 #### Formatter Known Issues
 
-Some commands cause the next line to be indented. For example:
-
-```autohotkey
-if (true)
-    MsgBox
-
-Loop % n
-    SoundBeep
-```
-
-Such code will be well formatted.
-
-However, the formatter doesn't work with nested commands:
-
-```autohotkey
-if (true)
-    if (true)
-        MsgBox
-
-Loop % n
-    if (true)
-        SoundBeep
-```
-
-As a workaround, use braces:
-
-```autohotkey
-if (true) {
-    if (true)
-        MsgBox
-}
-
-Loop % n {
-    if (true)
-        SoundBeep
-}
-```
+Look at [GitHub](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues?q=is%3Aopen+is%3Aissue+label%3Aformatter)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ AHK++ is a fork of [AutoHotkey Plus by cweijan](https://github.com/AutoHotkey-Pl
     -   [Folding](#folding)
     -   [Code Format](#code-format)
         -   [Formatter Directives](#formatter-directives)
+        -   [Formatter Known Issues](#formatter-known-issues)
 -   [Credits](#credits)
 
 ## Why AutoHotkey Plus Plus?
@@ -145,6 +146,46 @@ The only directive currently supported is `FormatBlockComment` and it's used as 
 ;All text inside block comment will be formatted like regular code.
 */
 ;@AHK++FormatBlockCommentOff
+```
+
+#### Formatter Known Issues
+
+There are commands, that can produce indent on single next line. For example:
+
+```autohotkey
+if (true)
+    MsgBox
+
+Loop % n
+    SoundBeep
+```
+
+Such code will be well formatted.
+
+But do not nest such commands. The next code will be formatted incorrectly:
+
+```autohotkey
+if (true)
+    if (true)
+        MsgBox
+
+Loop % n
+    if (true)
+        SoundBeep
+```
+
+Use their variants with braces:
+
+```autohotkey
+if (true) {
+    if (true)
+        MsgBox
+}
+
+Loop % n {
+    if (true)
+        SoundBeep
+}
 ```
 
 ## Credits


### PR DESCRIPTION
### Formatter Known Issues

There are commands, that can produce indent on single next line. For example:

```autohotkey
if (true)
    MsgBox

Loop % n
    SoundBeep
```

Such code will be well formatted.

But do not nest such commands. The next code will be formatted incorrectly:

```autohotkey
if (true)
    if (true)
        MsgBox

Loop % n
    if (true)
        SoundBeep
```

Use their variants with braces:

```autohotkey
if (true) {
    if (true)
        MsgBox
}

Loop % n {
    if (true)
        SoundBeep
}
```

Notifying @mark-wiemer
