### PR TITLE
Fix Switch-Case Formatting

### DIFF
--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -231,11 +231,11 @@ export const internalFormat = (
 
         // #IfWinActive, #IfWinExist with omit params OR #If without expression
         if (
-            purifiedLine.match(/#ifwinactive$/) ||
-            purifiedLine.match(/#ifwinnotactive$/) ||
-            purifiedLine.match(/#ifwinexist$/) ||
-            purifiedLine.match(/#ifwinnotexist$/) ||
-            purifiedLine.match(/#if$/)
+            purifiedLine.match(/^#ifwinactive$/) ||
+            purifiedLine.match(/^#ifwinnotactive$/) ||
+            purifiedLine.match(/^#ifwinexist$/) ||
+            purifiedLine.match(/^#ifwinnotexist$/) ||
+            purifiedLine.match(/^#if$/)
         ) {
             if (indentCodeAfterSharpDirective) {
                 if (tagDepth > 0) {
@@ -248,11 +248,11 @@ export const internalFormat = (
 
         // #IfWinActive, #IfWinExist with params OR #If with expression
         if (
-            purifiedLine.match(/#ifwinactive\b.+/) ||
-            purifiedLine.match(/#ifwinnotactive\b.+/) ||
-            purifiedLine.match(/#ifwinexist\b.+/) ||
-            purifiedLine.match(/#ifwinnotexist\b.+/) ||
-            purifiedLine.match(/#if\b.+/)
+            purifiedLine.match(/^#ifwinactive\b.+/) ||
+            purifiedLine.match(/^#ifwinnotactive\b.+/) ||
+            purifiedLine.match(/^#ifwinexist\b.+/) ||
+            purifiedLine.match(/^#ifwinnotexist\b.+/) ||
+            purifiedLine.match(/^#if\b.+/)
         ) {
             if (indentCodeAfterSharpDirective) {
                 if (tagDepth > 0) {

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -139,7 +139,7 @@ export const internalFormat = (
      * Generally, aside from whitespace and comments,
      * no other code can be written on the same line as a label.
      */
-    const label = /^\s*[^\s\t,`]+:\s*$/;
+    const label = /^[^\s\t,`]+:$/;
 
     const lines = stringToFormat.split('\n');
 
@@ -265,7 +265,7 @@ export const internalFormat = (
         }
 
         // Return or ExitApp
-        if (purifiedLine.match(/\b(return|exitapp)\b/) && tagDepth === depth) {
+        if (purifiedLine.match(/^(return|exitapp)\b/) && tagDepth === depth) {
             tagDepth = 0;
             depth--;
         }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -52,35 +52,35 @@ export const internalFormat = (
      *
      * `tagDepth === 0`:
      *
-     *      Indentation level was decreased by `Return` or `ExitApp` command, so they placed on same
-     *      indentation level as `Label`.
-     *      Decrement of indentation level by `Label` is disallowed (previous `Label` finished with `Return`
-     *      or `ExitApp` command and un-indent for fall-through scenario not needed).
-     *      Decrement indentation by one level for `#Directive` is allowed.
+     *    Indentation level was decreased by `Return` or `ExitApp` command, so they placed on same
+     *    indentation level as `Label`.
+     *    Decrement of indentation level by `Label` is disallowed (previous `Label` finished with `Return`
+     *    or `ExitApp` command and un-indent for fall-through scenario not needed).
+     *    Decrement indentation by one level for `#Directive` is allowed.
      *
      * `tagDepth === depth`:
      *
-     *      Current indentation level is in sync with `Label` indentation level (no additional indent added
-     *      by block `{}`, `oneCommandCode`, etc...).
-     *      `Return` or `ExitApp` commands allowed to be un-indented, so they will be placed on same
-     *      indentation level as `Label`.
-     *      `Label` allowed to be un-indented for fall-through scenario.
+     *    Current indentation level is in sync with `Label` indentation level (no additional indent added
+     *    by block `{}`, `oneCommandCode`, etc...).
+     *    `Return` or `ExitApp` commands allowed to be un-indented, so they will be placed on same
+     *    indentation level as `Label`.
+     *    `Label` allowed to be un-indented for fall-through scenario.
      *
      * `tagDepth !== depth`:
      *
-     *      `Return` or `ExitApp` commands disallowed to be un-indented, so they will obey indentation rules
-     *      as code above them (`Return` inside function, block `{}`, `oneCommandCode`, etc... stay on same
-     *      indentation level as code above them).
+     *    `Return` or `ExitApp` commands disallowed to be un-indented, so they will obey indentation rules
+     *    as code above them (`Return` inside function, block `{}`, `oneCommandCode`, etc... stay on same
+     *    indentation level as code above them).
      *
      * `tagDepth > 0` :
      *
-     *      `#Directive` allowed to be un-indented by `tagDepth` value (jump several indentation levels).
+     *    `#Directive` allowed to be un-indented by `tagDepth` value (jump several indentation levels).
      *
      * `tagDepth = depth`:
      *
-     *      Only `Label` makes syncing `tagDepth` with `depth`.
-     *      `Case:` and `Default:` must not make syncing to disallow `Return` and `ExitApp` un-indent
-     *      inside `Switch-Case` block.
+     *    Only `Label` makes syncing `tagDepth` with `depth`.
+     *    `Case:` and `Default:` must not make syncing to disallow `Return` and `ExitApp` un-indent
+     *    inside `Switch-Case` block.
      */
     let tagDepth = 0;
     /**

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -273,7 +273,10 @@ export const internalFormat = (
         }
 
         // Return or ExitApp
-        if (purifiedLine.match(/^(return|exitapp)\b/) && tagDepth === depth) {
+        if (
+            purifiedLine.match(/^(return|exit|exitapp)\b/) &&
+            tagDepth === depth
+        ) {
             tagDepth = 0;
             depth--;
         }

--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -264,20 +264,20 @@ export const internalFormat = (
             }
         }
 
-        // return or ExitApp
+        // Return or ExitApp
         if (purifiedLine.match(/\b(return|exitapp)\b/) && tagDepth === depth) {
             tagDepth = 0;
             depth--;
         }
 
-        // switch-case, label
+        // Switch-Case, Label:
         if (purifiedLine.match(/^\s*case.+?:\s*$/)) {
-            // case
+            // Case:
             // Do not make syncing (tagDepth = depth) here! Read tagDepth comment.
             tagDepth--;
             depth--;
         } else if (purifiedLine.match(label)) {
-            // default or hotkey
+            // Default: or Hotkey::
             if (indentCodeAfterLabel) {
                 if (tagDepth === depth) {
                     // De-indent label or hotkey, if they not end with 'return' command.
@@ -380,7 +380,7 @@ export const internalFormat = (
             depth++;
         }
 
-        // default or label
+        // Default: or Label:
         if (!moreOpenParens && purifiedLine.match(label)) {
             if (indentCodeAfterLabel) {
                 depth++;

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -75,6 +75,7 @@ const formatTests: FormatTest[] = [
         filenameRoot: 'insert-spaces-false',
         options: { insertSpaces: false },
     },
+    { filenameRoot: 'legacy-text-sharp-directive' },
     { filenameRoot: 'label-fall-through' },
     { filenameRoot: 'label-specific-name' },
     {

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -78,6 +78,7 @@ const formatTests: FormatTest[] = [
     { filenameRoot: 'legacy-text-sharp-directive' },
     { filenameRoot: 'label-fall-through' },
     { filenameRoot: 'label-specific-name' },
+    { filenameRoot: 'return-exit-exitapp' },
     {
         filenameRoot: 'tab-size-2',
         options: { tabSize: 2 },

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -28,6 +28,7 @@ const defaultOptions = {
 };
 const formatTests: FormatTest[] = [
     { filenameRoot: '25-multiline-string' },
+    { filenameRoot: '28-switch-case' },
     { filenameRoot: '40-command-inside-text' },
     { filenameRoot: '55-sharp-directive' },
     { filenameRoot: '56-return-command-after-label' },

--- a/src/test/suite/format/samples/28-switch-case.in.ahk
+++ b/src/test/suite/format/samples/28-switch-case.in.ahk
@@ -1,0 +1,31 @@
+; [Issue #28](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/28)
+{
+Switch SwitchValue {
+Case CaseValue1:
+Statements1
+Return
+Case CaseValue2a, CaseValue2b:
+Statements2
+Return
+Default:
+Statements3
+Return
+}
+}
+
+Switch SwitchValue
+{
+Case CaseValue1:
+Statements1
+Case CaseValue2a, CaseValue2b:
+Statements2
+Default:
+Statements3
+}
+
+Switch SwitchValue
+{
+Case CaseValue1: Statements1
+Case CaseValue1: Statements2
+Default: Statements3
+}

--- a/src/test/suite/format/samples/28-switch-case.out.ahk
+++ b/src/test/suite/format/samples/28-switch-case.out.ahk
@@ -1,0 +1,31 @@
+; [Issue #28](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/28)
+{
+    Switch SwitchValue {
+    Case CaseValue1:
+        Statements1
+        Return
+    Case CaseValue2a, CaseValue2b:
+        Statements2
+        Return
+    Default:
+        Statements3
+        Return
+    }
+}
+
+Switch SwitchValue
+{
+Case CaseValue1:
+    Statements1
+Case CaseValue2a, CaseValue2b:
+    Statements2
+Default:
+    Statements3
+}
+
+Switch SwitchValue
+{
+Case CaseValue1: Statements1
+Case CaseValue1: Statements2
+Default: Statements3
+}

--- a/src/test/suite/format/samples/legacy-text-sharp-directive.in.ahk
+++ b/src/test/suite/format/samples/legacy-text-sharp-directive.in.ahk
@@ -1,0 +1,2 @@
+str = text #if not directive
+;must be not indented

--- a/src/test/suite/format/samples/legacy-text-sharp-directive.out.ahk
+++ b/src/test/suite/format/samples/legacy-text-sharp-directive.out.ahk
@@ -1,0 +1,2 @@
+str = text #if not directive
+;must be not indented

--- a/src/test/suite/format/samples/return-exit-exitapp.in.ahk
+++ b/src/test/suite/format/samples/return-exit-exitapp.in.ahk
@@ -1,0 +1,23 @@
+Label:
+Sleep
+Return
+
+Label:
+Sleep
+Exit, ExitCode
+
+Label:
+Sleep
+ExitApp, ExitCode
+
+foo1() {
+Return
+}
+
+foo2() {
+Exit, ExitCode
+}
+
+foo() {
+ExitApp, ExitCode
+}

--- a/src/test/suite/format/samples/return-exit-exitapp.out.ahk
+++ b/src/test/suite/format/samples/return-exit-exitapp.out.ahk
@@ -1,0 +1,23 @@
+Label:
+    Sleep
+Return
+
+Label:
+    Sleep
+Exit, ExitCode
+
+Label:
+    Sleep
+ExitApp, ExitCode
+
+foo1() {
+    Return
+}
+
+foo2() {
+    Exit, ExitCode
+}
+
+foo() {
+    ExitApp, ExitCode
+}


### PR DESCRIPTION
Closes #28.

Changes proposed in this pull request:

Now it is possible to fix this error with a compromise: The `Return` command is placed at the same indentation level as the regular code within the special `Case:` and `Default:` labels. In this case `Return` don't belongs to `Case:` and `Default:` labels, it belongs to outer code (for example return from function, in which `Switch` used). Forcing `Return` to un-indent, as with regular `Label:`, brings unreadable "spaghetti" in the `formatterProvider.ts` code.

`Return` case:

```autohotkey
Switch SwitchValue {
Case CaseValue1:
    Statements1
    Return
Case CaseValue2a, CaseValue2b:
    Statements2
    Return
Default:
    Statements3
    Return
}
```

Regular case:
```autohotkey
Switch SwitchValue
{
Case CaseValue1:
    Statements1
Case CaseValue2a, CaseValue2b:
    Statements2
Default:
    Statements3
}

Switch SwitchValue
{
Case CaseValue1: Statements1
Case CaseValue1: Statements2
Default: Statements3
}
```
Additional changes:

- fixed comment above `tagDepth` to show properly in VS Code Hover
- updated some comments to be in style with others
- changed regexps for sharp directives to fix indentation in legacy text
- simplified and unified regexp of `Label:` and `Return|ExitApp` detection
- add missing `Exit` command to `Return|ExitApp` regexp

---

Notifying @mark-wiemer
